### PR TITLE
Bug fixes and Namespace support

### DIFF
--- a/nvgReader.py
+++ b/nvgReader.py
@@ -69,6 +69,14 @@ class Reader(object):
         # consider moving this to a seperate method
         self.version = self.dom.documentElement.getAttribute("version")
 
+        # update the namespace based on the version of the document
+        if self.version == '1.4.0':
+            self.namespace = namespaces['1.4.0']
+        elif self.version == '1.5.0':
+            self.namespace = namespaces['1.5.0']
+        elif self.version == '2.0.0':
+            self.namespace = namespaces['2.0.0']
+
         # need to define the outputs based on the datatypes in the nvg
         self.esriPolygon = []
         self.esriPolyline = []
@@ -83,9 +91,10 @@ class Reader(object):
 
 
     def _getElement(self,tag):
-        """Return all elements with given tag.
+        """Return all elements with given tag with the correct namespace for the
+        version of NVG.
         """
-        return self.dom.getElementsByTagName(tag)
+        return self.dom.getElementsByTagNameNS(self.namespace,tag)
 
     def _cleanPoints(self,points):
         """Cleans a string of point coordinate pairs and returns a list of

--- a/nvgReader.py
+++ b/nvgReader.py
@@ -184,8 +184,11 @@ class Reader(object):
         cY = centrePnt.firstPoint.Y
         rotation = math.radians(float(rotation))
         step = 1
-        if int(startangle) > int(endangle):
-            endangle=int(endangle) + 360
+        startangle = float(startangle)
+        endangle = float(endangle)
+
+        if startangle > endangle:
+            endangle=endangle + 360
 
         # generate points and rotate
         for theata in range(int(startangle),int(endangle),step):

--- a/nvgReader.py
+++ b/nvgReader.py
@@ -23,9 +23,10 @@ import xml.dom.minidom
 import arcpy
 import math
 
-# version 1.4 namespaces
-# this may not be needed if so it will be deleted
-namespaces = {'nvg':'http://tide.act.nato.int/schemas/2008/10/nvg'}
+# namespace based on the version of the NVG document.
+namespaces = {'1.4.0': 'http://tide.act.nato.int/schemas/2008/10/nvg',
+              '1.5.0': 'http://tide.act.nato.int/schemas/2009/10/nvg',
+              '2.0.0': 'https://tide.act.nato.int/schemas/2012/10/nvg'}
 
 # <a>, <g> and <composite> features not yet implemented
 


### PR DESCRIPTION
## Whats New?

Added support for the default NVG namespaces for versions 1.4.0, 1.5.0 and 2.0.0

Support for namespaces for versions other than 1.4.0 are added in preparation for reading the features for future versions. The code has not been tested against versions other than 1.4.0 changes in the specification may break the code.
